### PR TITLE
Prune dependencies for prod deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@eslint/eslintrc": "^1.2.1",
     "@reduxjs/toolkit": "^1.8.0",
-    "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
     "@types/lodash": "^4.14.182",
     "@types/react-datepicker": "^4.4.1",
     "@types/react-dom": "^18.0.4",
@@ -28,6 +24,10 @@
     "styled-components": "^5.3.3"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^1.2.1",
+    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/react": "^9.3.2",
+    "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^24.0.0",
     "@types/node": "^12.0.0",
     "@types/react": "^18.0.9",


### PR DESCRIPTION
When working on deploying this repo to prod (https://github.com/mitoc/geardb-ansible/issues/21), two changes were made as a result:

There turned out to be ~600MB of dependencies that needed to be installed. Looking closer, some of these were test dependencies; this PR moves those into `devDependencies` instead.

Details:

After running `yarn install --frozen-lockfile --production` with the original repo:
```
603M	node_modules/
```

Largest packages

```
900K	node_modules/clean-css
904K	node_modules/jest-environment-jsdom
904K	node_modules/jest-environment-node
908K	node_modules/babel-preset-react-app
908K	node_modules/jest-serializer
908K	node_modules/regenerator-transform
936K	node_modules/jest-mock
940K	node_modules/@react-aria
984K	node_modules/jest-watcher
996K	node_modules/esquery
```

After moving the testing dependencies, running `yarn install --production`:

```
433M	node_modules/
```

largest packages:
```
748K	node_modules/common-tags
756K	node_modules/neo-async
760K	node_modules/tsutils
816K	node_modules/core-js-compat
824K	node_modules/react-router-dom
828K	node_modules/resolve-url-loader
836K	node_modules/source-map
852K	node_modules/@pmmmwh
856K	node_modules/react-router
904K	node_modules/@csstools
912K	node_modules/clean-css
996K	node_modules/esquery
```

This saves ~150MB of space on the resource-limited production machine, but still enables development.

(why `jest` and various `jest`-related dependencies are installed for production, who knows. probably some downstream dependency packages were not careful about what is in their `dependencies` vs. `devDependencies`)