### PR TITLE
Release build/ directory on merge to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@
 name: Release
 
 on:
-  pull_request:
+  push:
     branches: [ main ]
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,18 +4,13 @@
 name: Release
 
 on:
-  push:
+  pull_request:
     branches: [ main ]
 
 jobs:
   release:
 
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [16.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
       # do all the steps from the CI workflow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,11 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    # do all the steps from the CI workflow
+    uses: ./.github/workflows/yarn-ci
+
+    # now do the CD-specific steps
     steps:
-      # do all the steps from the CI workflow
-    - uses: ./.github/workflows/yarn-ci
-      # now do the CD-specific steps
     - name: Set variables for tag generation
       id: vars
       run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+# Release a new build on push to main.
+# This will also get triggered after each PR is merged against main
+
+name: Release
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  release:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      # do all the steps from the CI workflow
+    - uses: ./.github/workflows/yarn-ci
+      # now do the CD-specific steps
+    - name: Set variables for tag generation
+      id: vars
+      run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+    - name: Generate release
+      uses: ncipollo/release-action@v1
+      with:
+        allowUpdates: false
+        artifacts: "build/*"
+        # don't use {{ github.sha }} here since that's the full SHA
+        tag: 1.0.0-${{ steps.vars.outputs.sha_short }}
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,22 +9,8 @@ on:
 
 jobs:
   release:
-
-    runs-on: ubuntu-latest
-
     # do all the steps from the CI workflow
-    uses: ./.github/workflows/yarn-ci.yml
-
-    # now do the CD-specific steps
-    steps:
-    - name: Set variables for tag generation
-      id: vars
-      run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-    - name: Generate release
-      uses: ncipollo/release-action@v1
-      with:
-        allowUpdates: false
-        artifacts: "build/*"
-        # don't use {{ github.sha }} here since that's the full SHA
-        tag: 1.0.0-${{ steps.vars.outputs.sha_short }}
-        token: ${{ secrets.GITHUB_TOKEN }}
+    # but also do the release step
+    uses: ./.github/workflows/yarn.yml
+    with:
+      release: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # do all the steps from the CI workflow
-    uses: ./.github/workflows/yarn-ci
+    uses: ./.github/workflows/yarn-ci.yml
 
     # now do the CD-specific steps
     steps:

--- a/.github/workflows/yarn-ci.yml
+++ b/.github/workflows/yarn-ci.yml
@@ -4,10 +4,11 @@
 name: Node.js CI
 
 on:
-  push:
-    branches: [ main ]
+  # runs on all pull requests against main
   pull_request:
     branches: [ main ]
+  # this is a reusable workflow that is called from the release workflow
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/yarn-ci.yml
+++ b/.github/workflows/yarn-ci.yml
@@ -34,14 +34,3 @@ jobs:
       uses: Borales/actions-yarn@v2.3.0
       with:
           cmd: build
-    - name: Set variables for tag generation
-      id: vars
-      run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-    - name: Generate release
-      uses: ncipollo/release-action@v1
-      with:
-        allowUpdates: false
-        artifacts: "build/*"
-        # don't use {{ github.sha }} here since that's the full SHA
-        tag: 1.0.0-${{ steps.vars.outputs.sha_short }}
-        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/yarn.yml
+++ b/.github/workflows/yarn.yml
@@ -34,9 +34,14 @@ jobs:
       uses: Borales/actions-yarn@v2.3.0
       with:
           cmd: build
+    - name: Set variables for tag generation
+      id: vars
+      run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
     - name: Generate release
       uses: ncipollo/release-action@v1
       with:
         allowUpdates: false
         artifacts: "build/*"
+        # don't use {{ github.sha }} here since that's the full SHA
+        tag: 1.0.0-${{ steps.vars.outputs.sha_short }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/yarn.yml
+++ b/.github/workflows/yarn.yml
@@ -24,7 +24,7 @@ jobs:
 
     outputs:
       # define the short-SHA here as an output of the build step
-      short-sha: ${{ steps.vars.outputs.sha_short }}
+      sha_short: ${{ steps.vars.outputs.sha_short }}
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/yarn.yml
+++ b/.github/workflows/yarn.yml
@@ -32,11 +32,11 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - name: Install production-level yarn dependencies
-      uses: Borales/actions-yarn@v2.3.0
+      uses: Borales/actions-yarn@v3.0.0
       with:
           cmd: install --frozen-lockfile --production
     - name: Build output for prod
-      uses: Borales/actions-yarn@v2.3.0
+      uses: Borales/actions-yarn@v3.0.0
       with:
           cmd: build
     - name: tar files together before artifact creation

--- a/.github/workflows/yarn.yml
+++ b/.github/workflows/yarn.yml
@@ -34,10 +34,9 @@ jobs:
       uses: Borales/actions-yarn@v2.3.0
       with:
           cmd: build
-    - name: Save build artifact
-      uses: actions/upload-artifact@v3.1.0
+    - name: Generate release
+      uses: ncipollo/release-action@v1
       with:
-          name: output
-          path: build/
-          # default retention settings set in repository settings
-          retention-days: 0
+        allowUpdates: false
+        artifacts: "build/*"
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/yarn.yml
+++ b/.github/workflows/yarn.yml
@@ -70,7 +70,7 @@ jobs:
       with:
         allowUpdates: false
         artifactErrorsFailBuild: true
-        artifacts: "build.zip"
+        artifacts: "build"
         # don't use {{ github.sha }} here since that's the full SHA
         tag: 1.0.0-${{ needs.build.outputs.sha_short }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/yarn.yml
+++ b/.github/workflows/yarn.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Node.js CI
+name: Yarn CI & CD
 
 on:
   # runs on all pull requests against main
@@ -14,11 +14,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [16.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
     - uses: actions/checkout@v3
@@ -35,3 +33,25 @@ jobs:
       uses: Borales/actions-yarn@v2.3.0
       with:
           cmd: build
+
+  # CD-specific job
+  release:
+    if: release == "true"
+    needs: build
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    - name: Set variables for tag generation
+      id: vars
+      run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+    - name: Generate release
+      uses: ncipollo/release-action@v1
+      with:
+        allowUpdates: false
+        artifacts: "build/*"
+        # don't use {{ github.sha }} here since that's the full SHA
+        tag: 1.0.0-${{ steps.vars.outputs.sha_short }}
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/yarn.yml
+++ b/.github/workflows/yarn.yml
@@ -22,6 +22,10 @@ jobs:
       matrix:
         node-version: [16.x]
 
+    outputs:
+      # define the short-SHA here as an output of the build step
+      short-sha: ${{ steps.vars.outputs.sha_short }}
+
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
@@ -37,6 +41,14 @@ jobs:
       uses: Borales/actions-yarn@v2.3.0
       with:
           cmd: build
+    - name: Upload artifact for release
+      uses: actions/upload-artifact@v3
+      with:
+        name: builddir
+        path: build/*
+    - name: Set variables for tag generation
+      id: vars
+      run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
 
   # CD-specific job
   release:
@@ -49,14 +61,15 @@ jobs:
         node-version: [16.x]
 
     steps:
-      - name: Set variables for tag generation
-        id: vars
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-      - name: Generate release
-        uses: ncipollo/release-action@v1
-        with:
-          allowUpdates: false
-          artifacts: "build/*"
-          # don't use {{ github.sha }} here since that's the full SHA
-          tag: 1.0.0-${{ steps.vars.outputs.sha_short }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Download artifact from build
+      uses: actions/download-artifact@v3
+      with:
+        name: builddir
+    - name: Generate release
+      uses: ncipollo/release-action@v1
+      with:
+        allowUpdates: false
+        artifacts: "build/*"
+        # don't use {{ github.sha }} here since that's the full SHA
+        tag: 1.0.0-${{ needs.build.outputs.sha_short }}
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/yarn.yml
+++ b/.github/workflows/yarn.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Download artifact from build
       uses: actions/download-artifact@v3
       with:
-        name: build.tar
+        name: build
     - name: Generate release
       uses: ncipollo/release-action@v1
       with:

--- a/.github/workflows/yarn.yml
+++ b/.github/workflows/yarn.yml
@@ -13,8 +13,6 @@ on:
       release:
         required: false
         type: boolean
-        # by default, don't run the release workflow
-        default: false
 
 jobs:
   build:
@@ -42,7 +40,7 @@ jobs:
 
   # CD-specific job
   release:
-    if: ${{ inputs.release == "true" }}
+    if: ${{ inputs.release }}
     needs: build
 
     runs-on: ubuntu-latest

--- a/.github/workflows/yarn.yml
+++ b/.github/workflows/yarn.yml
@@ -7,7 +7,6 @@ on:
   # runs on all pull requests against main
   pull_request:
     branches: [ main ]
-  # this is a reusable workflow that is called from the release workflow
   workflow_call:
     inputs:
       release:
@@ -23,7 +22,6 @@ jobs:
         node-version: [16.x]
 
     outputs:
-      # define the short-SHA here as an output of the build step
       sha_short: ${{ steps.vars.outputs.sha_short }}
 
     steps:

--- a/.github/workflows/yarn.yml
+++ b/.github/workflows/yarn.yml
@@ -9,6 +9,12 @@ on:
     branches: [ main ]
   # this is a reusable workflow that is called from the release workflow
   workflow_call:
+    inputs:
+      release:
+        required: false
+        type: boolean
+        # by default, don't run the release workflow
+        default: false
 
 jobs:
   build:
@@ -36,7 +42,7 @@ jobs:
 
   # CD-specific job
   release:
-    if: release == "true"
+    if: ${{ inputs.release == "true" }}
     needs: build
 
     runs-on: ubuntu-latest

--- a/.github/workflows/yarn.yml
+++ b/.github/workflows/yarn.yml
@@ -41,10 +41,10 @@ jobs:
       uses: Borales/actions-yarn@v2.3.0
       with:
           cmd: build
-    - name: Upload artifact for release
+    - name: Upload build.zip artifact for release
       uses: actions/upload-artifact@v3
       with:
-        name: builddir
+        name: build
         path: build/*
     - name: Set variables for tag generation
       id: vars
@@ -64,12 +64,13 @@ jobs:
     - name: Download artifact from build
       uses: actions/download-artifact@v3
       with:
-        name: builddir
+        name: build
     - name: Generate release
       uses: ncipollo/release-action@v1
       with:
         allowUpdates: false
-        artifacts: "build/*"
+        artifactErrorsFailBuild: true
+        artifacts: "build.zip"
         # don't use {{ github.sha }} here since that's the full SHA
         tag: 1.0.0-${{ needs.build.outputs.sha_short }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/yarn.yml
+++ b/.github/workflows/yarn.yml
@@ -65,10 +65,13 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: build
+        path: output
     - name: Generate release
       uses: ncipollo/release-action@v1
       with:
         allowUpdates: false
+        artifactErrorsFailBuild: true
+        artifacts: "output/*"
         # don't use {{ github.sha }} here since that's the full SHA
         tag: 1.0.0-${{ needs.build.outputs.sha_short }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/yarn.yml
+++ b/.github/workflows/yarn.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version: [16.x]
@@ -57,7 +57,7 @@ jobs:
     if: ${{ inputs.release }}
     needs: build
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version: [16.x]

--- a/.github/workflows/yarn.yml
+++ b/.github/workflows/yarn.yml
@@ -69,8 +69,6 @@ jobs:
       uses: ncipollo/release-action@v1
       with:
         allowUpdates: false
-        artifactErrorsFailBuild: true
-        artifacts: "build"
         # don't use {{ github.sha }} here since that's the full SHA
         tag: 1.0.0-${{ needs.build.outputs.sha_short }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/yarn.yml
+++ b/.github/workflows/yarn.yml
@@ -41,11 +41,13 @@ jobs:
       uses: Borales/actions-yarn@v2.3.0
       with:
           cmd: build
+    - name: tar files together before artifact creation
+      run: tar -cvf build.tar build/
     - name: Upload build.zip artifact for release
       uses: actions/upload-artifact@v3
       with:
         name: build
-        path: build/*
+        path: build.tar
     - name: Set variables for tag generation
       id: vars
       run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
@@ -64,14 +66,13 @@ jobs:
     - name: Download artifact from build
       uses: actions/download-artifact@v3
       with:
-        name: build
-        path: output
+        name: build.tar
     - name: Generate release
       uses: ncipollo/release-action@v1
       with:
         allowUpdates: false
         artifactErrorsFailBuild: true
-        artifacts: "output/*"
+        artifacts: "build.tar"
         # don't use {{ github.sha }} here since that's the full SHA
         tag: 1.0.0-${{ needs.build.outputs.sha_short }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/yarn.yml
+++ b/.github/workflows/yarn.yml
@@ -34,3 +34,10 @@ jobs:
       uses: Borales/actions-yarn@v2.3.0
       with:
           cmd: build
+    - name: Save build artifact
+      uses: actions/upload-artifact@v3.1.0
+      with:
+          name: output
+          path: build/
+          # default retention settings set in repository settings
+          retention-days: 0

--- a/.github/workflows/yarn.yml
+++ b/.github/workflows/yarn.yml
@@ -44,14 +44,15 @@ jobs:
       matrix:
         node-version: [16.x]
 
-    - name: Set variables for tag generation
-      id: vars
-      run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-    - name: Generate release
-      uses: ncipollo/release-action@v1
-      with:
-        allowUpdates: false
-        artifacts: "build/*"
-        # don't use {{ github.sha }} here since that's the full SHA
-        tag: 1.0.0-${{ steps.vars.outputs.sha_short }}
-        token: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Set variables for tag generation
+        id: vars
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+      - name: Generate release
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: false
+          artifacts: "build/*"
+          # don't use {{ github.sha }} here since that's the full SHA
+          tag: 1.0.0-${{ steps.vars.outputs.sha_short }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mitoc-gear-ui",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "dependencies": {
     "@eslint/eslintrc": "^1.2.1",


### PR DESCRIPTION
Running `yarn install` and `yarn build` on the prod server is too RAM-intensive, so instead we save the build artifacts here (since we try it in CI anyway), and will use this for deploy.

This adds a release workflow that runs only on merges to `main` (i.e. after the CI workflow has been completed), and releases the `build/` directory, tagging it with a (currently-hardcoded) `1.0.0-short-SHA`. The CI workflow is reused between steps.

A "release" is a `build.tar` file that contains a `build/` directory with the output of `yarn build`.

This was tested (and successfully created a release) by changing the following in `release.yml`:

```
on:
  push:
    branches: [ main ]
```

to 

```
on:
  pull_request:
    branches: [ main ]
```

then deleting the created release in the repository.