### PR TITLE
Gear Locations

### DIFF
--- a/src/apiClient/gear.ts
+++ b/src/apiClient/gear.ts
@@ -110,6 +110,7 @@ export type CreateGearArgs = {
   specification?: string;
   depositAmount?: number;
   description?: string;
+  location?: string;
 };
 
 async function createGear(

--- a/src/apiClient/gear.ts
+++ b/src/apiClient/gear.ts
@@ -53,6 +53,11 @@ export interface GearType {
   defaultDeposit: number;
 }
 
+export interface GearLocation {
+  id: number;
+  shorthand: string;
+}
+
 async function getGearRentalHistory(
   id: string,
   page?: number

--- a/src/apiClient/gear.ts
+++ b/src/apiClient/gear.ts
@@ -19,6 +19,10 @@ export interface GearSummary {
   type: {
     typeName: string;
   };
+  location: {
+    id: string;
+    shorthand: string;
+  };
 }
 
 export interface GearItem extends GearSummary {

--- a/src/components/GearLocationSelect.tsx
+++ b/src/components/GearLocationSelect.tsx
@@ -22,12 +22,9 @@ export function GearLocationSelect({ locations, onChange: onChangeProps }: Props
       label: allGearLocations.shorthand,
       ...allGearLocations,
     })) ?? [];
-  const values =
-    gearLocationOptions == null
-      ? null
-      : (locations
-          .map((id) => gearLocationOptions.find((opt) => opt.id === id))
-          .filter((opt) => opt != null) as GearLocationOption[]);
+  const values = gearLocationOptions.filter((opt) =>
+      locations.includes(opt.id)
+  );
   const onChange = useCallback(
     (options: MultiValue<GearLocationOption>) =>
       onChangeProps(options.map(parseOption)),

--- a/src/components/GearLocationSelect.tsx
+++ b/src/components/GearLocationSelect.tsx
@@ -1,0 +1,51 @@
+import { useCallback } from "react";
+import Select, { MultiValue } from "react-select";
+
+import { useGetGearLocationsQuery } from "redux/api";
+import { GearLocation } from "apiClient/gear";
+
+type GearLocationOption = GearLocation & {
+  value: number;
+  label: string;
+};
+
+type Props = {
+  locations: number[];
+  onChange: (groups: GearLocation[]) => void;
+};
+
+export function GearLocationSelect({ locations, onChange: onChangeProps }: Props) {
+  const { data: allGearLocations } = useGetGearLocationsQuery();
+  const gearLocationOptions =
+    allGearLocations?.map((allGearLocations) => ({
+      value: allGearLocations.id,
+      label: allGearLocations.shorthand,
+      ...allGearLocations,
+    })) ?? [];
+  const values =
+    gearLocationOptions == null
+      ? null
+      : (locations
+          .map((id) => gearLocationOptions.find((opt) => opt.id === id))
+          .filter((opt) => opt != null) as GearLocationOption[]);
+  const onChange = useCallback(
+    (options: MultiValue<GearLocationOption>) =>
+      onChangeProps(options.map(parseOption)),
+    [onChangeProps]
+  );
+
+  return (
+    <Select
+      className="flex-grow-1"
+      isMulti={true}
+      options={gearLocationOptions}
+      value={values}
+      onChange={onChange}
+    />
+  );
+}
+
+function parseOption(o: GearLocationOption): GearLocation {
+  const { value, label, ...other } = o;
+  return other;
+}

--- a/src/pages/Gear/AllGearPage/AllGearPage.tsx
+++ b/src/pages/Gear/AllGearPage/AllGearPage.tsx
@@ -45,6 +45,7 @@ export function AllGearPage() {
       renderer: DescriptionCell,
     },
     { key: "status", header: "Status", renderer: StatusCell },
+    { key: "location", header: "Location", renderer: LocationCell },
   ]);
 
   return (
@@ -150,6 +151,14 @@ function TypeCell({ item: gearItem }: { item: GearSummary }) {
           <strong className="text-warning">RESTRICTED</strong>
         </>
       )}
+    </>
+  );
+}
+
+function LocationCell({ item: gearItem }: { item: GearSummary }) {
+  return (
+    <>
+      {gearItem.location.shorthand}
     </>
   );
 }

--- a/src/pages/Gear/AllGearPage/AllGearPage.tsx
+++ b/src/pages/Gear/AllGearPage/AllGearPage.tsx
@@ -22,7 +22,7 @@ export function AllGearPage() {
   const [showFilters, setShowFilters] = useState<boolean>(
     !isEqual(filters, { retired: GearStatusFilter.exclude }) // Open the panel if filters are not the default
   );
-  const { gearTypes, broken, missing, retired, q } = filters;
+  const { gearTypes, broken, missing, retired, q, locations } = filters;
   const query = q ?? "";
   const setQuery = (q: string) => setFilters((filters) => ({ ...filters, q }));
 
@@ -33,6 +33,7 @@ export function AllGearPage() {
     broken: gearStatusToBoolean(broken),
     missing: gearStatusToBoolean(missing),
     retired: gearStatusToBoolean(retired),
+    locations: locations,
   });
 
   const myColumns = compact([

--- a/src/pages/Gear/AllGearPage/AllGearPage.tsx
+++ b/src/pages/Gear/AllGearPage/AllGearPage.tsx
@@ -46,7 +46,7 @@ export function AllGearPage() {
       renderer: DescriptionCell,
     },
     { key: "status", header: "Status", renderer: StatusCell },
-    { key: "location", header: "Location", renderer: LocationCell },
+    { key: "location", header: "Location", renderer: LocationCell, hideOnMobile: true },
   ]);
 
   return (

--- a/src/pages/Gear/AllGearPage/GearFilters.tsx
+++ b/src/pages/Gear/AllGearPage/GearFilters.tsx
@@ -1,6 +1,7 @@
 import { map } from "lodash";
 
 import { GearTypeSelect } from "components/GearTypeSelect";
+import { GearLocationSelect } from "components/GearLocationSelect";
 import { Select } from "components/Inputs/Select";
 
 export enum GearStatusFilter {
@@ -39,6 +40,10 @@ export function GearFilters({ filters, setFilters }: Props) {
 
       <div className="mb-2">
         <label>Locations:</label>
+        <GearLocationSelect
+          locations={filters.locations ?? []}
+          onChange={(locations) => update({ locations: map(locations, "id") })}
+        />
       </div>
 
       {gearStatus.map((status) => (

--- a/src/pages/Gear/AllGearPage/GearFilters.tsx
+++ b/src/pages/Gear/AllGearPage/GearFilters.tsx
@@ -15,6 +15,7 @@ export type Filters = {
   broken?: GearStatusFilter;
   retired?: GearStatusFilter;
   missing?: GearStatusFilter;
+  locations?: number[];
 };
 
 type Props = {
@@ -34,6 +35,10 @@ export function GearFilters({ filters, setFilters }: Props) {
           gearTypes={filters.gearTypes ?? []}
           onChange={(gearTypes) => update({ gearTypes: map(gearTypes, "id") })}
         />
+      </div>
+
+      <div className="mb-2">
+        <label>Locations:</label>
       </div>
 
       {gearStatus.map((status) => (

--- a/src/pages/Gear/AllGearPage/useGearFilter.ts
+++ b/src/pages/Gear/AllGearPage/useGearFilter.ts
@@ -50,7 +50,9 @@ function parse(params: URLSearchParams): Filters {
     ...(missing != null && { missing }),
     ...(!isEmpty(gearTypes) && {
       gearTypes: gearTypes!.split(",").map(Number),
-    ...(!isEmpty(locations) && { locations: locations!.split(",").map(Number) }),
+    }),
+    ...(!isEmpty(locations) && {
+      locations: locations!.split(",").map(Number),
     }),
   };
 }

--- a/src/pages/Gear/AllGearPage/useGearFilter.ts
+++ b/src/pages/Gear/AllGearPage/useGearFilter.ts
@@ -20,6 +20,7 @@ function serialize({
   broken,
   missing,
   retired,
+  locations,
 }: Filters): Record<string, string> {
   return {
     ...(q && { q }),
@@ -28,6 +29,7 @@ function serialize({
     ...(retired != null &&
       retired !== GearStatusFilter.exclude && { retired: String(retired) }),
     ...(!isEmpty(gearTypes) && { gearTypes: gearTypes!.map(String).join(",") }),
+    ...(!isEmpty(locations) && { locations: locations!.map(String).join(",") }),
   };
 }
 
@@ -39,6 +41,7 @@ function parse(params: URLSearchParams): Filters {
     parseStatus(params.get("retired")) ?? GearStatusFilter.exclude;
   const broken = parseStatus(params.get("broken"));
   const q = params.get("q") ?? "";
+  const locations = params.get("locations") ?? "";
 
   return {
     ...(!isEmpty(q) && { q }),
@@ -47,6 +50,7 @@ function parse(params: URLSearchParams): Filters {
     ...(missing != null && { missing }),
     ...(!isEmpty(gearTypes) && {
       gearTypes: gearTypes!.split(",").map(Number),
+    ...(!isEmpty(locations) && { locations: locations!.split(",").map(Number) }),
     }),
   };
 }

--- a/src/redux/api.ts
+++ b/src/redux/api.ts
@@ -61,9 +61,10 @@ export const gearDbApi = createApi({
         missing?: boolean;
         retired?: boolean;
         gearTypes?: number[];
+        locations?: number[];
       }
     >({
-      query: ({ q, page, gearTypes, broken, missing, retired }) => ({
+      query: ({ q, page, gearTypes, broken, missing, retired, locations }) => ({
         url: "gear/",
         params: {
           ...(q && { q }),
@@ -72,6 +73,7 @@ export const gearDbApi = createApi({
           ...(missing != null && { missing }),
           ...(retired != null && { retired }),
           ...(!isEmpty(gearTypes) && { gearTypes }),
+          ...(!isEmpty(locations) && { locations }),
         },
       }),
     }),
@@ -155,6 +157,7 @@ export function useGearList({
   broken,
   missing,
   retired,
+  locations,
 }: {
   q: string;
   page?: number;
@@ -162,6 +165,7 @@ export function useGearList({
   broken?: boolean;
   missing?: boolean;
   retired?: boolean;
+  locations?: number[];
 }) {
   const { data } = useGetGearListQuery({
     q: q?.trim(),
@@ -170,6 +174,7 @@ export function useGearList({
     broken,
     missing,
     retired,
+    locations,
   });
   const gearList = data?.results;
   const nbPages =

--- a/src/redux/api.ts
+++ b/src/redux/api.ts
@@ -6,6 +6,7 @@ import type {
   GearItem,
   GearSummary,
   GearType,
+  GearLocation,
   PurchasableItem,
 } from "apiClient/gear";
 import {
@@ -133,6 +134,9 @@ export const gearDbApi = createApi({
         },
       }),
     }),
+    getGearLocations: builder.query<GearLocation[], void>({
+      query: () => "/gear-locations/",
+    }),
   }),
 });
 
@@ -148,6 +152,7 @@ export const {
   useGetOfficeHoursQuery,
   useGetPersonSignupsQuery,
   useGetSignupsQuery,
+  useGetGearLocationsQuery,
 } = gearDbApi;
 
 export function useGearList({


### PR DESCRIPTION
- [x] Allow filtering for gear locations on the all-gear page

![Screenshot from 2023-02-25 21-40-35](https://user-images.githubusercontent.com/829379/221389236-dee0faec-6d1a-4198-8530-c5fad734b398.png)
- [x] Allow creation of new gear item with an override location (they are autopopulated with the `GearLocation` objects

![Screenshot from 2023-02-27 10-28-31](https://user-images.githubusercontent.com/829379/221606297-6c7bb507-8d63-4d62-a45e-aa5c8fa41c38.png)

Notes:
* Must be paired with: https://github.com/mitoc/gear-db-django/pull/436
* I don't love how the `GearLocationSelect` object is basically identical to the `GearTypeSelect` object. There must be a way to do this with either generics or type unions. Or it should be a single class with better-stored props/state. Happy to explore this further if this is blocking a review.

I'd actually love to just get this through review as I work through editing the location for an individual gear item, since the search/filter feature is already useful. I'll get the gear item editing in the next CR