### PR TITLE
Edit location of gear item

### DIFF
--- a/src/apiClient/gear.ts
+++ b/src/apiClient/gear.ts
@@ -20,7 +20,7 @@ export interface GearSummary {
     typeName: string;
   };
   location: {
-    id: string;
+    id: number;
     shorthand: string;
   };
 }

--- a/src/apiClient/gear.ts
+++ b/src/apiClient/gear.ts
@@ -124,13 +124,15 @@ async function editGearItem(
   specification: string,
   description: string,
   size: string,
-  depositAmount: number
+  depositAmount: number,
+  location: number,
 ) {
   return request(`/gear/${id}/`, "PATCH", {
     specification,
     description,
     size,
     depositAmount,
+    location,
   });
 }
 

--- a/src/pages/Gear/GearInfoPanel.tsx
+++ b/src/pages/Gear/GearInfoPanel.tsx
@@ -62,6 +62,7 @@ export function GearInfoPanel({ gearItem, refreshGear }: Props) {
           <Field value={gearItem.description} title="Description" />
           <Field value={gearItem.size} title="Size" />
           <Field value={fmtAmount(gearItem.depositAmount)} title="Deposit" />
+          <Field value={gearItem.location.shorthand} title="Location" />
         </>
       )}
 

--- a/src/pages/Gear/GearItemEditForm.tsx
+++ b/src/pages/Gear/GearItemEditForm.tsx
@@ -88,6 +88,7 @@ export function GearItemEditForm({ gearItem, closeForm, refreshGear }: Props) {
           isMulti={false}
           options={optionsGearLocations}
           onChange={setGearLocation}
+          value={optionsGearLocations.find((o) => o.id === location.id)}
         />
       </div>
 

--- a/src/pages/Gear/GearItemEditForm.tsx
+++ b/src/pages/Gear/GearItemEditForm.tsx
@@ -1,12 +1,13 @@
-import { editGearItem, GearSummary } from "apiClient/gear";
+import { editGearItem, GearSummary, GearLocation } from "apiClient/gear";
 import { NumberField } from "components/Inputs/NumberField";
 import { TextArea } from "components/Inputs/TextArea";
 import { TextField } from "components/Inputs/TextField";
-import { LabeledInput } from "components/Inputs/LabeledInput";
 import { useState } from "react";
 import Select from "react-select";
 import { useGetGearLocationsQuery } from "redux/api";
 
+
+type GearLocationOption = GearLocation & { value: number; label: string };
 
 type Props = {
   gearItem: GearSummary;
@@ -25,19 +26,29 @@ export function GearItemEditForm({ gearItem, closeForm, refreshGear }: Props) {
   const [deposit, setDeposit] = useState<number | null>(gearItem.depositAmount);
   const [submitted, setSubmitted] = useState<boolean>(false);
   const { data: gearLocations } = useGetGearLocationsQuery();
-  const optionsGearLocations = 
-    gearLocations?.map((gearLocation) => ({
-      value: gearLocation.id,
-      label: gearLocation.shorthand,
-      ...gearLocation
+  const optionsGearLocations =
+    gearLocations?.map((gearLocations) => ({
+      value: gearLocations.id,
+      label: gearLocations.shorthand,
+      ...gearLocations,
     })) ?? [];
+  const [location, setLocation] = useState<GearLocation>(gearItem.location);
+
+  const setGearLocation = (gearLocationOption: GearLocationOption | null) => {
+    if (gearLocationOption != null) {
+      setLocation({
+        id: gearLocationOption.id,
+        shorthand: gearLocationOption.shorthand,
+      })
+    }
+  };
 
   const onSubmit = () => {
     setSubmitted(true);
     if (deposit == null) {
       return;
     }
-    editGearItem(gearItem.id, specification, description, size, deposit, 1).then(      () => {
+    editGearItem(gearItem.id, specification, description, size, deposit, location.id).then(      () => {
         closeForm();
         refreshGear();
       }
@@ -70,31 +81,15 @@ export function GearItemEditForm({ gearItem, closeForm, refreshGear }: Props) {
         <div className="invalid-feedback">This field is required</div>
       </label>
 
-      <LabeledInput
-        title="Gear location (override):"
-        name="location"
-        renderComponent={({ value, onChange, onBlur, invalid }: any) => {
-          return (
-            <Select
-              isLoading={!gearLocations}
-              options={optionsGearLocations}
-              className={`w-100 ${invalid ? "is-invalid" : ""}`}
-              styles={{
-                control: (base, state) =>
-                  !invalid
-                    ? base
-                    : {
-                        ...base,
-                        ...invalidFormControlStyle,
-                      },
-              }}
-              value={value}
-              onChange={onChange}
-              onBlur={onBlur}
-            />
-          );
-        }}
-      />
+      <div className="mb-2">
+        <label>Location:</label>
+        <Select
+          className="flex-grow-1"
+          isMulti={false}
+          options={optionsGearLocations}
+          onChange={setGearLocation}
+        />
+      </div>
 
       <div className="d-flex justify-content-between mb-3">
         <button
@@ -111,13 +106,3 @@ export function GearItemEditForm({ gearItem, closeForm, refreshGear }: Props) {
     </form>
   );
 }
-
-// This is copy-pasted from bootstrap, since we can't set the inner class of React-Select
-const invalidFormControlStyle = {
-  borderColor: "#dc3545",
-  paddingRight: "calc(1.5em + .75rem)",
-  backgroundImage: `url("data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 12 12%27 width=%2712%27 height=%2712%27 fill=%27none%27 stroke=%27%23dc3545%27%3e%3ccircle cx=%276%27 cy=%276%27 r=%274.5%27/%3e%3cpath stroke-linejoin=%27round%27 d=%27M5.8 3.6h.4L6 6.5z%27/%3e%3ccircle cx=%276%27 cy=%278.2%27 r=%27.6%27 fill=%27%23dc3545%27 stroke=%27none%27/%3e%3c/svg%3e")`,
-  backgroundRepeat: "no-repeat",
-  backgroundPosition: "right calc(.375em + .1875rem) center",
-  backgroundSize: "calc(.75em + .375rem) calc(.75em + .375rem)",
-};

--- a/src/pages/Gear/GearItemEditForm.tsx
+++ b/src/pages/Gear/GearItemEditForm.tsx
@@ -2,7 +2,11 @@ import { editGearItem, GearSummary } from "apiClient/gear";
 import { NumberField } from "components/Inputs/NumberField";
 import { TextArea } from "components/Inputs/TextArea";
 import { TextField } from "components/Inputs/TextField";
+import { LabeledInput } from "components/Inputs/LabeledInput";
 import { useState } from "react";
+import Select from "react-select";
+import { useGetGearLocationsQuery } from "redux/api";
+
 
 type Props = {
   gearItem: GearSummary;
@@ -20,14 +24,20 @@ export function GearItemEditForm({ gearItem, closeForm, refreshGear }: Props) {
   const [size, setSize] = useState<string>(gearItem.size ?? "");
   const [deposit, setDeposit] = useState<number | null>(gearItem.depositAmount);
   const [submitted, setSubmitted] = useState<boolean>(false);
+  const { data: gearLocations } = useGetGearLocationsQuery();
+  const optionsGearLocations = 
+    gearLocations?.map((gearLocation) => ({
+      value: gearLocation.id,
+      label: gearLocation.shorthand,
+      ...gearLocation
+    })) ?? [];
 
   const onSubmit = () => {
     setSubmitted(true);
     if (deposit == null) {
       return;
     }
-    editGearItem(gearItem.id, specification, description, size, deposit).then(
-      () => {
+    editGearItem(gearItem.id, specification, description, size, deposit, 1).then(      () => {
         closeForm();
         refreshGear();
       }
@@ -60,6 +70,32 @@ export function GearItemEditForm({ gearItem, closeForm, refreshGear }: Props) {
         <div className="invalid-feedback">This field is required</div>
       </label>
 
+      <LabeledInput
+        title="Gear location (override):"
+        name="location"
+        renderComponent={({ value, onChange, onBlur, invalid }: any) => {
+          return (
+            <Select
+              isLoading={!gearLocations}
+              options={optionsGearLocations}
+              className={`w-100 ${invalid ? "is-invalid" : ""}`}
+              styles={{
+                control: (base, state) =>
+                  !invalid
+                    ? base
+                    : {
+                        ...base,
+                        ...invalidFormControlStyle,
+                      },
+              }}
+              value={value}
+              onChange={onChange}
+              onBlur={onBlur}
+            />
+          );
+        }}
+      />
+
       <div className="d-flex justify-content-between mb-3">
         <button
           type="button"
@@ -75,3 +111,13 @@ export function GearItemEditForm({ gearItem, closeForm, refreshGear }: Props) {
     </form>
   );
 }
+
+// This is copy-pasted from bootstrap, since we can't set the inner class of React-Select
+const invalidFormControlStyle = {
+  borderColor: "#dc3545",
+  paddingRight: "calc(1.5em + .75rem)",
+  backgroundImage: `url("data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 12 12%27 width=%2712%27 height=%2712%27 fill=%27none%27 stroke=%27%23dc3545%27%3e%3ccircle cx=%276%27 cy=%276%27 r=%274.5%27/%3e%3cpath stroke-linejoin=%27round%27 d=%27M5.8 3.6h.4L6 6.5z%27/%3e%3ccircle cx=%276%27 cy=%278.2%27 r=%27.6%27 fill=%27%23dc3545%27 stroke=%27none%27/%3e%3c/svg%3e")`,
+  backgroundRepeat: "no-repeat",
+  backgroundPosition: "right calc(.375em + .1875rem) center",
+  backgroundSize: "calc(.75em + .375rem) calc(.75em + .375rem)",
+};


### PR DESCRIPTION
This CR allows the editing of an individual gear item's location from the gear info page. It also displays the location directly on the gear item page (in addition to the already-displayed location on the all-gear page).

![Screenshot from 2023-03-05 14-39-08](https://user-images.githubusercontent.com/829379/222981978-3c5dff2d-0401-4b8d-b3f4-098e8ebed5dc.png)


![Screenshot from 2023-03-05 14-38-59](https://user-images.githubusercontent.com/829379/222981981-3510f1c2-19fd-45b5-9125-dacee09534c4.png)
