### PR TITLE
Only allow desk officers to add credit

### DIFF
--- a/src/pages/People/PersonProfile/PersonProfile.tsx
+++ b/src/pages/People/PersonProfile/PersonProfile.tsx
@@ -17,7 +17,7 @@ import { WaiverForm } from "./WaiverForm";
 export function PersonProfile() {
   const [isEditing, setEditing] = useState<boolean>(false);
   const [showDeskCreditForm, setShowDeskCreditForm] = useState<boolean>(false);
-  const { isOfficer } = usePermissions();
+  const { isDeskManager } = usePermissions();
 
   const onEdit = () => {
     setEditing(true);
@@ -89,7 +89,7 @@ export function PersonProfile() {
           <div>
             <strong>Mitoc credit:</strong> ${person.mitocCredit}
           </div>
-          {isOfficer && (
+          {isDeskManager && (
             <ToggleExpandButton
               onClick={() => setShowDeskCreditForm((current) => !current)}
               isOpen={showDeskCreditForm}


### PR DESCRIPTION
Front-end for https://github.com/mitoc/gear-db-django/pull/486
Per decision of the bod yesterday, we only want to allow the desk captains and gear manager to give desk credit.