### PR TITLE
Cross-tab cache invalidation

### DIFF
--- a/src/pages/Approvals/AddNewApproval.tsx
+++ b/src/pages/Approvals/AddNewApproval.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { useDispatch } from "react-redux";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import {
@@ -9,7 +8,7 @@ import {
 import { APIError as APIErrorClass } from "src/apiClient/client";
 import { APIErrorType } from "src/apiClient/types";
 import { useSetPageTitle } from "src/hooks";
-import { gearDbApi } from "src/redux/api";
+import { invalidateCache } from "src/redux/store";
 
 import { AddNewApprovalForm } from "./AddNewApprovalForm";
 
@@ -22,12 +21,11 @@ export default function AddNewApproval() {
   const searchParams = new URLSearchParams(location.search);
   const personId = searchParams.get("personId");
 
-  const dispatch = useDispatch();
   const onSubmit = (args: CreateNewApprovalArgs) => {
     createNewApproval(args)
       .then(() => {
         setError(undefined);
-        dispatch(gearDbApi.util.invalidateTags(["Approvals"]));
+        invalidateCache(["Approvals"]);
         if (personId != null) {
           navigate(`/people/${personId}?tab=approvals`);
         } else {

--- a/src/pages/Approvals/AddNewApproval.tsx
+++ b/src/pages/Approvals/AddNewApproval.tsx
@@ -8,6 +8,7 @@ import {
 import { APIError as APIErrorClass } from "src/apiClient/client";
 import { APIErrorType } from "src/apiClient/types";
 import { useSetPageTitle } from "src/hooks";
+import { TagType } from "src/redux/api";
 import { invalidateCache } from "src/redux/store";
 
 import { AddNewApprovalForm } from "./AddNewApprovalForm";
@@ -25,7 +26,7 @@ export default function AddNewApproval() {
     createNewApproval(args)
       .then(() => {
         setError(undefined);
-        invalidateCache(["Approvals"]);
+        invalidateCache([TagType.Approvals]);
         if (personId != null) {
           navigate(`/people/${personId}?tab=approvals`);
         } else {

--- a/src/pages/Gear/GearInfoPanel.tsx
+++ b/src/pages/Gear/GearInfoPanel.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import type { GearSummary } from "src/apiClient/gear";
 import { newApprovalUI } from "src/featureFlags";
 import { fmtAmount } from "src/lib/fmtNumber";
+import { TagType } from "src/redux/api";
 import { useConfig } from "src/redux/hooks";
 import { invalidateCache } from "src/redux/store";
 
@@ -80,7 +81,7 @@ export function GearInfoPanel({ gearItem }: Props) {
           gearItem={gearItem}
           closeForm={() => setEditing(false)}
           refreshGear={() => {
-            invalidateCache(["GearItems"]);
+            invalidateCache([TagType.GearItems]);
           }}
         />
       )}
@@ -111,7 +112,7 @@ export function GearInfoPanel({ gearItem }: Props) {
           formType={formToShow}
           gearItem={gearItem}
           onChange={() => {
-            invalidateCache(["GearItems"]);
+            invalidateCache([TagType.GearItems]);
             setFormToShow(GearStatusFormType.none);
           }}
         />

--- a/src/pages/Gear/GearInfoPanel.tsx
+++ b/src/pages/Gear/GearInfoPanel.tsx
@@ -5,14 +5,15 @@ import type { GearSummary } from "src/apiClient/gear";
 import { newApprovalUI } from "src/featureFlags";
 import { fmtAmount } from "src/lib/fmtNumber";
 import { useConfig } from "src/redux/hooks";
+import { invalidateCache } from "src/redux/store";
 
 import { GearItemEditForm } from "./GearItemEditForm";
 import { GearStatus } from "./GearStatus";
 import { GearStatusForm, GearStatusFormType } from "./GearStatusForm";
 
-type Props = { gearItem: GearSummary; refreshGear: () => void };
+type Props = { gearItem: GearSummary };
 
-export function GearInfoPanel({ gearItem, refreshGear }: Props) {
+export function GearInfoPanel({ gearItem }: Props) {
   const [formToShow, setFormToShow] = useState<GearStatusFormType>(
     GearStatusFormType.none,
   );
@@ -78,7 +79,9 @@ export function GearInfoPanel({ gearItem, refreshGear }: Props) {
         <GearItemEditForm
           gearItem={gearItem}
           closeForm={() => setEditing(false)}
-          refreshGear={refreshGear}
+          refreshGear={() => {
+            invalidateCache(["GearItems"]);
+          }}
         />
       )}
 
@@ -108,7 +111,7 @@ export function GearInfoPanel({ gearItem, refreshGear }: Props) {
           formType={formToShow}
           gearItem={gearItem}
           onChange={() => {
-            refreshGear();
+            invalidateCache(["GearItems"]);
             setFormToShow(GearStatusFormType.none);
           }}
         />

--- a/src/pages/Gear/GearItemPage.tsx
+++ b/src/pages/Gear/GearItemPage.tsx
@@ -4,6 +4,7 @@ import { addNote } from "src/apiClient/gear";
 import { Notes } from "src/components/Notes";
 import { useSetPageTitle } from "src/hooks";
 import { useGetGearItemQuery } from "src/redux/api";
+import { invalidateCache } from "src/redux/store";
 
 import { GearInfoPanel } from "./GearInfoPanel";
 import { GearPicture } from "./GearPicture";
@@ -12,7 +13,7 @@ import { GearRentalsHistory } from "./GearRentalsHistory";
 export default function GearItemPage() {
   const gearId = useParams<{ gearId: string }>().gearId!;
   useSetPageTitle(gearId);
-  const { data: gearItem, refetch: refreshGear } = useGetGearItemQuery(gearId);
+  const { data: gearItem } = useGetGearItemQuery(gearId);
 
   if (gearItem == null) {
     return null;
@@ -20,11 +21,13 @@ export default function GearItemPage() {
   return (
     <div className="row">
       <div className="col-12 col-md-5 p-2">
-        <GearInfoPanel gearItem={gearItem} refreshGear={refreshGear} />
-        <GearPicture gearItem={gearItem} refreshGear={refreshGear} />
+        <GearInfoPanel gearItem={gearItem} />
+        <GearPicture gearItem={gearItem} />
         <Notes
           notes={gearItem.notes}
-          onAdd={(note) => addNote(gearId, note).then(refreshGear)}
+          onAdd={(note) =>
+            addNote(gearId, note).then(() => invalidateCache(["GearItems"]))
+          }
         />
       </div>
       <div className="col-12 col-md-7 p-2">

--- a/src/pages/Gear/GearItemPage.tsx
+++ b/src/pages/Gear/GearItemPage.tsx
@@ -3,7 +3,7 @@ import { useParams } from "react-router-dom";
 import { addNote } from "src/apiClient/gear";
 import { Notes } from "src/components/Notes";
 import { useSetPageTitle } from "src/hooks";
-import { useGetGearItemQuery } from "src/redux/api";
+import { TagType, useGetGearItemQuery } from "src/redux/api";
 import { invalidateCache } from "src/redux/store";
 
 import { GearInfoPanel } from "./GearInfoPanel";
@@ -26,7 +26,9 @@ export default function GearItemPage() {
         <Notes
           notes={gearItem.notes}
           onAdd={(note) =>
-            addNote(gearId, note).then(() => invalidateCache(["GearItems"]))
+            addNote(gearId, note).then(() =>
+              invalidateCache([TagType.GearItems]),
+            )
           }
         />
       </div>

--- a/src/pages/Gear/GearPicture.tsx
+++ b/src/pages/Gear/GearPicture.tsx
@@ -4,16 +4,16 @@ import { useState } from "react";
 import styled from "styled-components";
 
 import { GearItem } from "src/apiClient/gear";
+import { invalidateCache } from "src/redux/store";
 
 import { PicturePickerModal } from "./PicturePickerModal";
 import { PicturePlaceholder } from "./PicturePlaceholder";
 
 type Props = {
   gearItem: GearItem;
-  refreshGear: () => void;
 };
 
-export function GearPicture({ gearItem, refreshGear }: Props) {
+export function GearPicture({ gearItem }: Props) {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
   return (
@@ -40,7 +40,7 @@ export function GearPicture({ gearItem, refreshGear }: Props) {
           isOpen={isModalOpen}
           close={() => setIsModalOpen(false)}
           item={gearItem}
-          refreshGear={refreshGear}
+          refreshGear={() => invalidateCache(["GearItems"])}
         />
       )}
     </>

--- a/src/pages/Gear/GearPicture.tsx
+++ b/src/pages/Gear/GearPicture.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import styled from "styled-components";
 
 import { GearItem } from "src/apiClient/gear";
+import { TagType } from "src/redux/api";
 import { invalidateCache } from "src/redux/store";
 
 import { PicturePickerModal } from "./PicturePickerModal";
@@ -40,7 +41,7 @@ export function GearPicture({ gearItem }: Props) {
           isOpen={isModalOpen}
           close={() => setIsModalOpen(false)}
           item={gearItem}
-          refreshGear={() => invalidateCache(["GearItems"])}
+          refreshGear={() => invalidateCache([TagType.GearItems])}
         />
       )}
     </>

--- a/src/pages/People/PeoplePage/PersonPageContext.tsx
+++ b/src/pages/People/PeoplePage/PersonPageContext.tsx
@@ -5,6 +5,7 @@ import React, { useContext, useState } from "react";
 import { RenterApproval } from "src/apiClient/approvals";
 import { GearSummary } from "src/apiClient/gear";
 import { checkoutGear, Person, Rental, returnGear } from "src/apiClient/people";
+import { invalidateCache } from "src/redux/store";
 
 import { ItemToPurchase } from "../types";
 
@@ -14,7 +15,6 @@ type PersonPageContextType = ReturnType<typeof useMakePersonPageContext>;
 
 type Props = {
   person: Person;
-  refreshPerson: () => void;
   approvals: RenterApproval[];
 };
 
@@ -44,7 +44,7 @@ export function usePersonPageContext() {
   return context;
 }
 
-function useMakePersonPageContext({ person, refreshPerson, approvals }: Props) {
+function useMakePersonPageContext({ person, approvals }: Props) {
   const checkoutBasketBase = useBasket<GearSummary>();
   const returnBasketBase = useBasket<Rental>();
   const purchaseBasket = useBasket<ItemToPurchase>();
@@ -115,7 +115,6 @@ function useMakePersonPageContext({ person, refreshPerson, approvals }: Props) {
     person,
     approvals,
     isApproved,
-    refreshPerson,
     purchaseBasket,
     returnBasket: {
       ...returnBasketBase,
@@ -139,7 +138,7 @@ function useMakePersonPageContext({ person, refreshPerson, approvals }: Props) {
         ).then(() => {
           returnBasketBase.clear();
           purchaseBasket.clear();
-          refreshPerson();
+          invalidateCache(["People"]);
         });
       },
     },
@@ -149,7 +148,7 @@ function useMakePersonPageContext({ person, refreshPerson, approvals }: Props) {
         const gearIDs = map(checkoutBasketBase.items, "id");
         return checkoutGear(person.id, gearIDs).then(() => {
           checkoutBasketBase.clear();
-          refreshPerson();
+          invalidateCache(["People"]);
         });
       },
     },

--- a/src/pages/People/PeoplePage/PersonPageContext.tsx
+++ b/src/pages/People/PeoplePage/PersonPageContext.tsx
@@ -5,6 +5,7 @@ import React, { useContext, useState } from "react";
 import { RenterApproval } from "src/apiClient/approvals";
 import { GearSummary } from "src/apiClient/gear";
 import { checkoutGear, Person, Rental, returnGear } from "src/apiClient/people";
+import { TagType } from "src/redux/api";
 import { invalidateCache } from "src/redux/store";
 
 import { ItemToPurchase } from "../types";
@@ -138,7 +139,7 @@ function useMakePersonPageContext({ person, approvals }: Props) {
         ).then(() => {
           returnBasketBase.clear();
           purchaseBasket.clear();
-          invalidateCache(["People"]);
+          invalidateCache([TagType.People]);
         });
       },
     },
@@ -148,7 +149,7 @@ function useMakePersonPageContext({ person, approvals }: Props) {
         const gearIDs = map(checkoutBasketBase.items, "id");
         return checkoutGear(person.id, gearIDs).then(() => {
           checkoutBasketBase.clear();
-          invalidateCache(["People"]);
+          invalidateCache([TagType.People]);
         });
       },
     },

--- a/src/pages/People/PersonPage.tsx
+++ b/src/pages/People/PersonPage.tsx
@@ -4,7 +4,11 @@ import { useParams } from "react-router-dom";
 import { addNote, archiveNote } from "src/apiClient/people";
 import { Notes } from "src/components/Notes";
 import { useSetPageTitle } from "src/hooks";
-import { useGetPersonQuery, useGetRenterApprovalsQuery } from "src/redux/api";
+import {
+  TagType,
+  useGetPersonQuery,
+  useGetRenterApprovalsQuery,
+} from "src/redux/api";
 import { invalidateCache } from "src/redux/store";
 
 import { BuyGear } from "./BuyGear";
@@ -70,12 +74,12 @@ function PersonPageInner() {
           notes={person.notes}
           onAdd={(note) => {
             return addNote(person.id, note).then(() =>
-              invalidateCache(["People"]),
+              invalidateCache([TagType.People]),
             );
           }}
           onArchive={(noteId) => {
             archiveNote(person.id, noteId).then(() =>
-              invalidateCache(["People"]),
+              invalidateCache([TagType.People]),
             );
           }}
         />

--- a/src/pages/People/PersonProfile/FrequentFlyerForm.tsx
+++ b/src/pages/People/PersonProfile/FrequentFlyerForm.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import DatePicker from "react-datepicker";
 
 import { addFFChecks, Person } from "src/apiClient/people";
+import { TagType } from "src/redux/api";
 import { invalidateCache } from "src/redux/store";
 
 import { getNextExpirationDate } from "./utils";
@@ -48,7 +49,7 @@ export function FrequentFlyerForm({ person, onClose }: Props) {
           onClick={(evt) => {
             evt.preventDefault();
             addFFChecks(person.id, date, checkNumber).then(() => {
-              invalidateCache(["People"]);
+              invalidateCache([TagType.People]);
               onClose();
             });
           }}

--- a/src/pages/People/PersonProfile/FrequentFlyerForm.tsx
+++ b/src/pages/People/PersonProfile/FrequentFlyerForm.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import DatePicker from "react-datepicker";
 
 import { addFFChecks, Person } from "src/apiClient/people";
-import { useGetPersonQuery } from "src/redux/api";
+import { invalidateCache } from "src/redux/store";
 
 import { getNextExpirationDate } from "./utils";
 
@@ -14,7 +14,6 @@ type Props = {
 };
 
 export function FrequentFlyerForm({ person, onClose }: Props) {
-  const { refetch: refreshPerson } = useGetPersonQuery(String(person.id));
   const initial = getNextExpirationDate();
   const [date, setDate] = useState<Date>(initial);
   const [checkNumber, setCheckNumber] = useState<string>("");
@@ -49,7 +48,7 @@ export function FrequentFlyerForm({ person, onClose }: Props) {
           onClick={(evt) => {
             evt.preventDefault();
             addFFChecks(person.id, date, checkNumber).then(() => {
-              refreshPerson();
+              invalidateCache(["People"]);
               onClose();
             });
           }}

--- a/src/pages/People/PersonProfile/MembershipForm.tsx
+++ b/src/pages/People/PersonProfile/MembershipForm.tsx
@@ -5,7 +5,8 @@ import DatePicker from "react-datepicker";
 
 import { addMembership, Person } from "src/apiClient/people";
 import { Select } from "src/components/Inputs/Select";
-import { useGetAffiliationsQuery, useGetPersonQuery } from "src/redux/api";
+import { useGetAffiliationsQuery } from "src/redux/api";
+import { invalidateCache } from "src/redux/store";
 
 import { getNextExpirationDate } from "./utils";
 
@@ -15,7 +16,6 @@ type Props = {
 };
 
 export function MembershipForm({ person, onClose }: Props) {
-  const { refetch: refreshPerson } = useGetPersonQuery(String(person.id));
   const { data: affiliations = [] } = useGetAffiliationsQuery();
   const affiliationOptions = affiliations.map(({ id, name }) => ({
     value: id,
@@ -63,7 +63,7 @@ export function MembershipForm({ person, onClose }: Props) {
               return;
             }
             addMembership(person.id, date, membershipType).then(() => {
-              refreshPerson();
+              invalidateCache(["People"]);
               onClose();
             });
           }}

--- a/src/pages/People/PersonProfile/MembershipForm.tsx
+++ b/src/pages/People/PersonProfile/MembershipForm.tsx
@@ -5,7 +5,7 @@ import DatePicker from "react-datepicker";
 
 import { addMembership, Person } from "src/apiClient/people";
 import { Select } from "src/components/Inputs/Select";
-import { useGetAffiliationsQuery } from "src/redux/api";
+import { TagType, useGetAffiliationsQuery } from "src/redux/api";
 import { invalidateCache } from "src/redux/store";
 
 import { getNextExpirationDate } from "./utils";
@@ -63,7 +63,7 @@ export function MembershipForm({ person, onClose }: Props) {
               return;
             }
             addMembership(person.id, date, membershipType).then(() => {
-              invalidateCache(["People"]);
+              invalidateCache([TagType.People]);
               onClose();
             });
           }}

--- a/src/pages/People/PersonProfile/MitocCreditForm.tsx
+++ b/src/pages/People/PersonProfile/MitocCreditForm.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import { addMitocCredit, Person } from "src/apiClient/people";
 import { NumberField } from "src/components/Inputs/NumberField";
-import { useGetPersonQuery } from "src/redux/api";
+import { invalidateCache } from "src/redux/store";
 
 type Props = {
   person: Person;
@@ -10,7 +10,6 @@ type Props = {
 };
 
 export function MitocCreditForm({ person, onClose }: Props) {
-  const { refetch: refreshPerson } = useGetPersonQuery(String(person.id));
   const [amount, setAmount] = useState<number | null>(15);
   return (
     <div>
@@ -21,7 +20,7 @@ export function MitocCreditForm({ person, onClose }: Props) {
             return;
           }
           addMitocCredit(person.id, amount).then(() => {
-            refreshPerson();
+            invalidateCache(["People"]);
             onClose();
           });
         }}

--- a/src/pages/People/PersonProfile/MitocCreditForm.tsx
+++ b/src/pages/People/PersonProfile/MitocCreditForm.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 import { addMitocCredit, Person } from "src/apiClient/people";
 import { NumberField } from "src/components/Inputs/NumberField";
+import { TagType } from "src/redux/api";
 import { invalidateCache } from "src/redux/store";
 
 type Props = {
@@ -20,7 +21,7 @@ export function MitocCreditForm({ person, onClose }: Props) {
             return;
           }
           addMitocCredit(person.id, amount).then(() => {
-            invalidateCache(["People"]);
+            invalidateCache([TagType.People]);
             onClose();
           });
         }}

--- a/src/pages/People/PersonProfile/PeopleGroups.tsx
+++ b/src/pages/People/PersonProfile/PeopleGroups.tsx
@@ -4,13 +4,13 @@ import { useState } from "react";
 import { PeopleGroup, Person, updatePersonGroups } from "src/apiClient/people";
 import { GroupSelect } from "src/components/GroupSelect";
 import { useCurrentUser, usePermissions } from "src/redux/auth";
+import { invalidateCache } from "src/redux/store";
 
 type Props = {
   person: Person;
-  refreshPerson: () => void;
 };
 
-export default function PeopleGroups({ person, refreshPerson }: Props) {
+export default function PeopleGroups({ person }: Props) {
   const [showGroupsForm, setShowGroupForms] = useState<boolean>(false);
   const { user } = useCurrentUser();
   const { isOfficer } = usePermissions();
@@ -53,7 +53,6 @@ export default function PeopleGroups({ person, refreshPerson }: Props) {
     <PeopleGroupsForm
       isOfficer={isOfficer}
       person={person}
-      refreshPerson={refreshPerson}
       closeForm={() => setShowGroupForms(false)}
     />
   );
@@ -61,7 +60,7 @@ export default function PeopleGroups({ person, refreshPerson }: Props) {
 
 function PeopleGroupsForm({
   person,
-  refreshPerson,
+
   closeForm,
   isOfficer,
 }: Props & { isOfficer?: boolean; closeForm: () => void }) {
@@ -72,7 +71,7 @@ function PeopleGroupsForm({
       person.id,
       groups.map((g) => g.id),
     ).then(() => {
-      refreshPerson();
+      invalidateCache(["People"]);
       closeForm();
     });
 

--- a/src/pages/People/PersonProfile/PeopleGroups.tsx
+++ b/src/pages/People/PersonProfile/PeopleGroups.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 
 import { PeopleGroup, Person, updatePersonGroups } from "src/apiClient/people";
 import { GroupSelect } from "src/components/GroupSelect";
+import { TagType } from "src/redux/api";
 import { useCurrentUser, usePermissions } from "src/redux/auth";
 import { invalidateCache } from "src/redux/store";
 
@@ -71,7 +72,7 @@ function PeopleGroupsForm({
       person.id,
       groups.map((g) => g.id),
     ).then(() => {
-      invalidateCache(["People"]);
+      invalidateCache([TagType.People]);
       closeForm();
     });
 

--- a/src/pages/People/PersonProfile/PersonEditForm.tsx
+++ b/src/pages/People/PersonProfile/PersonEditForm.tsx
@@ -7,11 +7,11 @@ import { Form } from "src/components/Inputs/Form";
 import { LabeledInput } from "src/components/Inputs/LabeledInput";
 import { validateEmail } from "src/lib/validation";
 import { useCurrentUser } from "src/redux/auth";
+import { invalidateCache } from "src/redux/store";
 
 type Props = {
   person: Person;
   closeForm: () => void;
-  refreshPerson: () => void;
 };
 
 type FormValues = {
@@ -21,7 +21,7 @@ type FormValues = {
   altEmails: { value: string }[];
 };
 
-export function PersonEditForm({ person, closeForm, refreshPerson }: Props) {
+export function PersonEditForm({ person, closeForm }: Props) {
   const { user } = useCurrentUser();
   const formObject = useForm<FormValues>({
     defaultValues: {
@@ -43,7 +43,7 @@ export function PersonEditForm({ person, closeForm, refreshPerson }: Props) {
     const altEmails = map(rawAltEmails, "value").filter((v) => !isEmpty(v));
     editPerson(person.id, firstName, lastName, email, altEmails).then(() => {
       closeForm();
-      refreshPerson();
+      invalidateCache(["People"]);
     });
   };
   const isPersonUser = person.groups.some(

--- a/src/pages/People/PersonProfile/PersonEditForm.tsx
+++ b/src/pages/People/PersonProfile/PersonEditForm.tsx
@@ -6,6 +6,7 @@ import { editPerson, Person } from "src/apiClient/people";
 import { Form } from "src/components/Inputs/Form";
 import { LabeledInput } from "src/components/Inputs/LabeledInput";
 import { validateEmail } from "src/lib/validation";
+import { TagType } from "src/redux/api";
 import { useCurrentUser } from "src/redux/auth";
 import { invalidateCache } from "src/redux/store";
 
@@ -43,7 +44,7 @@ export function PersonEditForm({ person, closeForm }: Props) {
     const altEmails = map(rawAltEmails, "value").filter((v) => !isEmpty(v));
     editPerson(person.id, firstName, lastName, email, altEmails).then(() => {
       closeForm();
-      invalidateCache(["People"]);
+      invalidateCache([TagType.People]);
     });
   };
   const isPersonUser = person.groups.some(

--- a/src/pages/People/PersonProfile/PersonProfile.tsx
+++ b/src/pages/People/PersonProfile/PersonProfile.tsx
@@ -23,7 +23,7 @@ export function PersonProfile() {
     setEditing(true);
   };
 
-  const { person, refreshPerson } = usePersonPageContext();
+  const { person } = usePersonPageContext();
 
   return (
     <StyledDiv className="border rounded-2 p-2 mb-3 bg-light">
@@ -56,14 +56,10 @@ export function PersonProfile() {
       )}
 
       {isEditing && (
-        <PersonEditForm
-          person={person}
-          closeForm={() => setEditing(false)}
-          refreshPerson={refreshPerson}
-        />
+        <PersonEditForm person={person} closeForm={() => setEditing(false)} />
       )}
 
-      <PeopleGroups person={person} refreshPerson={refreshPerson} />
+      <PeopleGroups person={person} />
       <ExpirableTile
         title="Membership"
         person={person}

--- a/src/pages/People/PersonProfile/WaiverForm.tsx
+++ b/src/pages/People/PersonProfile/WaiverForm.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import DatePicker from "react-datepicker";
 
 import { addWaiver, Person } from "src/apiClient/people";
+import { TagType } from "src/redux/api";
 import { invalidateCache } from "src/redux/store";
 
 import { getNextExpirationDate } from "./utils";
@@ -35,7 +36,7 @@ export function WaiverForm({ person, onClose }: Props) {
           onClick={(evt) => {
             evt.preventDefault();
             addWaiver(person.id, date).then(() => {
-              invalidateCache(["People"]);
+              invalidateCache([TagType.People]);
               onClose();
             });
           }}

--- a/src/pages/People/PersonProfile/WaiverForm.tsx
+++ b/src/pages/People/PersonProfile/WaiverForm.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import DatePicker from "react-datepicker";
 
 import { addWaiver, Person } from "src/apiClient/people";
-import { useGetPersonQuery } from "src/redux/api";
+import { invalidateCache } from "src/redux/store";
 
 import { getNextExpirationDate } from "./utils";
 
@@ -14,7 +14,6 @@ type Props = {
 };
 
 export function WaiverForm({ person, onClose }: Props) {
-  const { refetch: refreshPerson } = useGetPersonQuery(String(person.id));
   const initial = getNextExpirationDate();
   const [date, setDate] = useState<Date>(initial);
   return (
@@ -36,7 +35,7 @@ export function WaiverForm({ person, onClose }: Props) {
           onClick={(evt) => {
             evt.preventDefault();
             addWaiver(person.id, date).then(() => {
-              refreshPerson();
+              invalidateCache(["People"]);
               onClose();
             });
           }}

--- a/src/redux/api.ts
+++ b/src/redux/api.ts
@@ -22,6 +22,8 @@ import {
   Signup,
 } from "src/apiClient/types";
 
+const tagTypes = ["Approvals", "GearItems", "People"] as const;
+export type TagType = (typeof tagTypes)[number];
 export const gearDbApi = createApi({
   reducerPath: "gearDbApi",
   baseQuery: fetchBaseQuery({
@@ -30,7 +32,7 @@ export const gearDbApi = createApi({
     paramsSerializer: (params) =>
       queryString.stringify(params, { arrayFormat: "none" }),
   }),
-  tagTypes: ["Approvals"],
+  tagTypes,
   endpoints: (builder) => ({
     getConfig: builder.query<Config, void>({
       query: () => `config/`,
@@ -39,6 +41,7 @@ export const gearDbApi = createApi({
     }),
     getPerson: builder.query<Person, string>({
       query: (personID) => `people/${personID}/`,
+      providesTags: ["People"],
     }),
     getPersonList: builder.query<
       ListWrapper<PersonSummary>,
@@ -58,9 +61,11 @@ export const gearDbApi = createApi({
           ...(!isEmpty(groups) && { groups }),
         },
       }),
+      providesTags: ["People"],
     }),
     getGearItem: builder.query<GearItem, string>({
       query: (gearItemID) => `gear/${gearItemID}/`,
+      providesTags: ["GearItems"],
     }),
     getGearList: builder.query<
       ListWrapper<GearSummary>,
@@ -97,6 +102,7 @@ export const gearDbApi = createApi({
           ...(!isEmpty(locations) && { locations }),
         },
       }),
+      providesTags: ["GearItems"],
     }),
     getGearTypePictures: builder.query<string[], string | number>({
       query: (gearType) => `/gear-types/${gearType}/pictures`,

--- a/src/redux/api.ts
+++ b/src/redux/api.ts
@@ -22,8 +22,12 @@ import {
   Signup,
 } from "src/apiClient/types";
 
-const tagTypes = ["Approvals", "GearItems", "People"] as const;
-export type TagType = (typeof tagTypes)[number];
+export enum TagType {
+  Approvals = "Approvals",
+  GearItems = "GearItems",
+  People = "People",
+}
+
 export const gearDbApi = createApi({
   reducerPath: "gearDbApi",
   baseQuery: fetchBaseQuery({
@@ -32,7 +36,7 @@ export const gearDbApi = createApi({
     paramsSerializer: (params) =>
       queryString.stringify(params, { arrayFormat: "none" }),
   }),
-  tagTypes,
+  tagTypes: Object.values(TagType),
   endpoints: (builder) => ({
     getConfig: builder.query<Config, void>({
       query: () => `config/`,
@@ -41,7 +45,7 @@ export const gearDbApi = createApi({
     }),
     getPerson: builder.query<Person, string>({
       query: (personID) => `people/${personID}/`,
-      providesTags: ["People"],
+      providesTags: [TagType.People],
     }),
     getPersonList: builder.query<
       ListWrapper<PersonSummary>,
@@ -61,11 +65,11 @@ export const gearDbApi = createApi({
           ...(!isEmpty(groups) && { groups }),
         },
       }),
-      providesTags: ["People"],
+      providesTags: [TagType.People],
     }),
     getGearItem: builder.query<GearItem, string>({
       query: (gearItemID) => `gear/${gearItemID}/`,
-      providesTags: ["GearItems"],
+      providesTags: [TagType.GearItems],
     }),
     getGearList: builder.query<
       ListWrapper<GearSummary>,
@@ -102,7 +106,7 @@ export const gearDbApi = createApi({
           ...(!isEmpty(locations) && { locations }),
         },
       }),
-      providesTags: ["GearItems"],
+      providesTags: [TagType.GearItems],
     }),
     getGearTypePictures: builder.query<string[], string | number>({
       query: (gearType) => `/gear-types/${gearType}/pictures`,
@@ -170,7 +174,7 @@ export const gearDbApi = createApi({
           past,
         },
       }),
-      providesTags: ["Approvals"],
+      providesTags: [TagType.Approvals],
     }),
     getRenterApprovals: builder.query<
       ListWrapper<RenterApproval>,
@@ -182,7 +186,7 @@ export const gearDbApi = createApi({
           past,
         },
       }),
-      providesTags: ["Approvals"],
+      providesTags: [TagType.Approvals],
     }),
     getGearLocations: builder.query<GearLocation[], void>({
       query: () => "/gear-locations/",

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,6 +1,6 @@
 import { Action, configureStore, ThunkAction } from "@reduxjs/toolkit";
 
-import { gearDbApi } from "./api";
+import { gearDbApi, TagType } from "./api";
 import authReducer from "./auth/authSlice";
 
 export const store = configureStore({
@@ -11,6 +11,23 @@ export const store = configureStore({
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware().concat(gearDbApi.middleware),
 });
+
+// Set up a broacast channel for cross-tab invalidation
+const updateChannel =
+  "BroadcastChannel" in window ? new BroadcastChannel("rtk-sync") : undefined;
+
+type EventType = { tags: TagType[] };
+
+export function invalidateCache(tags: TagType[]) {
+  store.dispatch(gearDbApi.util.invalidateTags(tags));
+  updateChannel?.postMessage({ tags } satisfies EventType);
+}
+
+if (updateChannel != null) {
+  updateChannel.onmessage = (e: MessageEvent<EventType>) => {
+    store.dispatch(gearDbApi.util.invalidateTags(e.data.tags));
+  };
+}
 
 export type AppDispatch = typeof store.dispatch;
 export type RootState = ReturnType<typeof store.getState>;


### PR DESCRIPTION
Fixes #57 

- Use RTK's cache invalidation for gear and people install of manually refetching data on update
- Use `BroadcastChannel` to invalidate data across browser tabs and windows