### PR TITLE
Fix OH signup filtering by approval

### DIFF
--- a/src/pages/OfficeHours/RequestDeskCreditPage/RequestDeskCreditForm.tsx
+++ b/src/pages/OfficeHours/RequestDeskCreditPage/RequestDeskCreditForm.tsx
@@ -38,6 +38,7 @@ export function RequestDeskCreditForm({ onRequestSubmitted }: Props) {
   const { data, refetch } = useGetPersonSignupsQuery({
     personID: user!.id,
     approved: false,
+    orderBy: "-date",
   });
   const today = dayjs().format("YYYY-MM-DD");
 

--- a/src/redux/api.ts
+++ b/src/redux/api.ts
@@ -138,7 +138,7 @@ export const gearDbApi = createApi({
       query: ({ personID, approved, page, orderBy }) => ({
         url: `/people/${personID}/office-hour-signups/`,
         params: {
-          ...(approved && { approved }),
+          ...(approved != null && { approved }),
           ...(page != null && { page }),
           ...(orderBy != null && { orderBy }),
         },


### PR DESCRIPTION
On the request credit page, the filtering to only include non-approved requests was not effective, so we would query all signups. 
On top of that, we were also sorting data chronologically, so we were only getting the 50 oldest approvals.

For folks with more than 50 signups, we would therefore not load the more recent office hours, and desk workers couldn't request credit for them. 